### PR TITLE
refactor: remove unnecessary pk->str & str->pk transforms

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,8 +1,6 @@
 use solana_program::pubkey::Pubkey;
-use std::str::FromStr;
 
-pub const SOL_MINT: &str = "So11111111111111111111111111111111111111112";
-
+#[inline(always)]
 pub fn sol_mint() -> Pubkey {
-    Pubkey::from_str(SOL_MINT).unwrap()
+    spl_token::native_mint::id()
 }

--- a/src/dex/meteora/constants.rs
+++ b/src/dex/meteora/constants.rs
@@ -1,20 +1,30 @@
-use solana_program::pubkey::Pubkey;
-use std::str::FromStr;
+use solana_program::{pubkey, pubkey::Pubkey};
 
+const METEORA_DLMM_PROGRAM_ID: Pubkey = pubkey!("LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo");
+const METEORA_DLMM_EVENT_AUTHORITY: Pubkey =
+    pubkey!("D1ZN9Wj1fRSUQfCjhvnu1hqDMT7hzjzBBpi12nVniYD6");
+
+const METEORA_DAMM_PROGRAM_ID: Pubkey = pubkey!("Eo7WjKq67rjJQSZxS6z3YkapzY3eMj6Xy8X5EQVn5UaB");
+const METEORA_VAULT_PROGRAM_ID: Pubkey = pubkey!("24Uqj9JCLxUeoC3hGfh5W3s9FM9uCHDS2SG3LYwBpyTi");
+
+#[inline(always)]
 pub fn dlmm_program_id() -> Pubkey {
-    Pubkey::from_str("LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo").unwrap()
+    METEORA_DLMM_PROGRAM_ID
 }
 
+#[inline(always)]
 pub fn dlmm_event_authority() -> Pubkey {
-    Pubkey::from_str("D1ZN9Wj1fRSUQfCjhvnu1hqDMT7hzjzBBpi12nVniYD6").unwrap()
+    METEORA_DLMM_EVENT_AUTHORITY
 }
 
+#[inline(always)]
 pub fn damm_program_id() -> Pubkey {
-    Pubkey::from_str("Eo7WjKq67rjJQSZxS6z3YkapzY3eMj6Xy8X5EQVn5UaB").unwrap()
+    METEORA_DAMM_PROGRAM_ID
 }
 
+#[inline(always)]
 pub fn vault_program_id() -> Pubkey {
-    Pubkey::from_str("24Uqj9JCLxUeoC3hGfh5W3s9FM9uCHDS2SG3LYwBpyTi").unwrap()
+    METEORA_VAULT_PROGRAM_ID
 }
 
 pub const BIN_ARRAY: &[u8] = b"bin_array";

--- a/src/dex/pump/constants.rs
+++ b/src/dex/pump/constants.rs
@@ -1,13 +1,14 @@
-use solana_program::pubkey::Pubkey;
-use std::str::FromStr;
+use solana_program::{pubkey, pubkey::Pubkey};
 
-pub const PUMP_PROGRAM_ID: &str = "pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA";
-pub const PUMP_FEE_WALLET: &str = "JCRGumoE9Qi5BBgULTgdgTLjSgkCMSbF62ZZfGs84JeU";
+const PUMP_PROGRAM_ID: Pubkey = pubkey!("pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA");
+const PUMP_FEE_WALLET: Pubkey = pubkey!("JCRGumoE9Qi5BBgULTgdgTLjSgkCMSbF62ZZfGs84JeU");
 
+#[inline(always)]
 pub fn pump_program_id() -> Pubkey {
-    Pubkey::from_str(PUMP_PROGRAM_ID).unwrap()
+    PUMP_PROGRAM_ID
 }
 
+#[inline(always)]
 pub fn pump_fee_wallet() -> Pubkey {
-    Pubkey::from_str(PUMP_FEE_WALLET).unwrap()
+    PUMP_FEE_WALLET
 }

--- a/src/dex/raydium/constants.rs
+++ b/src/dex/raydium/constants.rs
@@ -1,24 +1,34 @@
-use solana_program::pubkey::Pubkey;
-use std::str::FromStr;
+use solana_program::{pubkey, pubkey::Pubkey};
 
+const RAYDIUM_AMM_PROGRAM_ID: Pubkey = pubkey!("675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8");
+const RAYDIUM_AMM_AUTHORITY: Pubkey = pubkey!("5Q544fKrFoe6tsEbD7S8EmxGTJYAKtTVhAW5Q5pge4j1");
+
+const RAYDIUM_CPMM_PROGRAM_ID: Pubkey = pubkey!("CPMMoo8L3F4NbTegBCKVNunggL7H1ZpdTHKxQB5qKP1C");
+const RAYDIUM_CPMM_AUTHORITY: Pubkey = pubkey!("GpMZbSM2GgvTKHJirzeGfMFoaZ8UR2X7F4v8vHTvxFbL");
+
+const RAYDIUM_CLMM_PROGRAM_ID: Pubkey = pubkey!("CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK");
+
+#[inline(always)]
 pub fn raydium_program_id() -> Pubkey {
-    Pubkey::from_str("675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8").unwrap()
+    RAYDIUM_AMM_PROGRAM_ID
 }
 
+#[inline(always)]
 pub fn raydium_authority() -> Pubkey {
-    Pubkey::from_str("5Q544fKrFoe6tsEbD7S8EmxGTJYAKtTVhAW5Q5pge4j1").unwrap()
+    RAYDIUM_AMM_AUTHORITY
 }
 
-
-
+#[inline(always)]
 pub fn raydium_cp_program_id() -> Pubkey {
-    Pubkey::from_str("CPMMoo8L3F4NbTegBCKVNunggL7H1ZpdTHKxQB5qKP1C").unwrap()
+    RAYDIUM_CPMM_PROGRAM_ID
 }
 
+#[inline(always)]
 pub fn raydium_cp_authority() -> Pubkey {
-    Pubkey::from_str("GpMZbSM2GgvTKHJirzeGfMFoaZ8UR2X7F4v8vHTvxFbL").unwrap()
+    RAYDIUM_CPMM_AUTHORITY
 }
 
+#[inline(always)]
 pub fn raydium_clmm_program_id() -> Pubkey {
-    Pubkey::from_str("CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK").unwrap()
+    RAYDIUM_CLMM_PROGRAM_ID
 }

--- a/src/dex/whirlpool/constants.rs
+++ b/src/dex/whirlpool/constants.rs
@@ -1,10 +1,11 @@
-use solana_program::pubkey::Pubkey;
-use std::str::FromStr;
+use solana_program::{pubkey, pubkey::Pubkey};
 
-pub const WHIRLPOOL_PROGRAM_ID: &str = "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc";
+const WHIRLPOOL_PROGRAM_ID: Pubkey = pubkey!("whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc");
+
 pub const MAX_TICK_INDEX: i32 = 443636;
 pub const MIN_TICK_INDEX: i32 = -443636;
 
+#[inline(always)]
 pub fn whirlpool_program_id() -> Pubkey {
-    Pubkey::from_str(WHIRLPOOL_PROGRAM_ID).unwrap()
+    WHIRLPOOL_PROGRAM_ID
 }

--- a/src/kamino.rs
+++ b/src/kamino.rs
@@ -1,20 +1,19 @@
 use solana_program::instruction::{AccountMeta, Instruction};
-use solana_program::pubkey::Pubkey;
 use solana_program::sysvar;
-use std::str::FromStr;
-use crate::constants::SOL_MINT;
+use solana_program::{pubkey, pubkey::Pubkey};
 
-pub const KAMINO_LENDING_PROGRAM_ID: &str = "KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD";
+const KAMINO_LENDING_PROGRAM_ID: Pubkey = pubkey!("KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD");
 
-pub const KAMINO_LENDING_MARKET: &str = "H6rHXmXoCQvq8Ue81MqNh7ow5ysPa1dSozwW3PU1dDH6";
-pub const KAMINO_LENDING_MARKET_AUTHORITY: &str = "Dx8iy2o46sK1DzWbEcznqSKeLbLVeu7otkibA3WohGAj";
+const KAMINO_LENDING_MARKET: Pubkey = pubkey!("H6rHXmXoCQvq8Ue81MqNh7ow5ysPa1dSozwW3PU1dDH6");
+const KAMINO_LENDING_MARKET_AUTHORITY: Pubkey =
+    pubkey!("Dx8iy2o46sK1DzWbEcznqSKeLbLVeu7otkibA3WohGAj");
 
-pub const KAMINO_SOL_RESERVE: &str = "6gTJfuPHEg6uRAijRkMqNc9kan4sVZejKMxmvx2grT1p";
-pub const KAMINO_SOL_RESERVE_LIQUIDITY: &str = "ywaaLvG7t1vXJo8sT3UzE8yzzZtxLM7Fmev64Jbooye";
-pub const KAMINO_SOL_FEE_RECEIVER: &str = "EQ7hw63aBS7aPQqXsoxaaBxiwbEzaAiY9Js6tCekkqxf";
+const KAMINO_SOL_RESERVE: Pubkey = pubkey!("6gTJfuPHEg6uRAijRkMqNc9kan4sVZejKMxmvx2grT1p");
+const KAMINO_SOL_RESERVE_LIQUIDITY: Pubkey = pubkey!("ywaaLvG7t1vXJo8sT3UzE8yzzZtxLM7Fmev64Jbooye");
+const KAMINO_SOL_FEE_RECEIVER: Pubkey = pubkey!("EQ7hw63aBS7aPQqXsoxaaBxiwbEzaAiY9Js6tCekkqxf");
 
-pub const KAMINO_REFERRER_TOKEN_STATE: &str = "KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD";
-pub const KAMINO_REFERRER_ACCOUNT: &str = "KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD";
+const KAMINO_REFERRER_TOKEN_STATE: Pubkey = pubkey!("KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD");
+const KAMINO_REFERRER_ACCOUNT: Pubkey = pubkey!("KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD");
 
 pub const KAMINO_ADDITIONAL_COMPUTE_UNITS: u32 = 80_000;
 
@@ -45,15 +44,15 @@ pub fn get_kamino_flashloan_borrow_ix(
     wallet_pk: &Pubkey,
     destination_token_account: Pubkey,
 ) -> anyhow::Result<Instruction> {
-    let kamino_program_id = Pubkey::from_str(KAMINO_LENDING_PROGRAM_ID)?;
-    let lending_market = Pubkey::from_str(KAMINO_LENDING_MARKET)?;
-    let lending_market_authority = Pubkey::from_str(KAMINO_LENDING_MARKET_AUTHORITY)?;
-    let reserve = Pubkey::from_str(KAMINO_SOL_RESERVE)?;
-    let reserve_liquidity_mint = Pubkey::from_str(SOL_MINT)?;
-    let reserve_source_liquidity = Pubkey::from_str(KAMINO_SOL_RESERVE_LIQUIDITY)?;
-    let fee_receiver = Pubkey::from_str(KAMINO_SOL_FEE_RECEIVER)?;
-    let referrer_token_state = Pubkey::from_str(KAMINO_REFERRER_TOKEN_STATE)?;
-    let referrer_account = Pubkey::from_str(KAMINO_REFERRER_ACCOUNT)?;
+    let kamino_program_id = KAMINO_LENDING_PROGRAM_ID;
+    let lending_market = KAMINO_LENDING_MARKET;
+    let lending_market_authority = KAMINO_LENDING_MARKET_AUTHORITY;
+    let reserve = KAMINO_SOL_RESERVE;
+    let reserve_liquidity_mint = spl_token::native_mint::id();
+    let reserve_source_liquidity = KAMINO_SOL_RESERVE_LIQUIDITY;
+    let fee_receiver = KAMINO_SOL_FEE_RECEIVER;
+    let referrer_token_state = KAMINO_REFERRER_TOKEN_STATE;
+    let referrer_account = KAMINO_REFERRER_ACCOUNT;
 
     let accounts = vec![
         AccountMeta::new(*wallet_pk, true), // userTransferAuthority
@@ -82,15 +81,15 @@ pub fn get_kamino_flashloan_repay_ix(
     source_token_account: Pubkey,
     borrow_instruction_index: u8,
 ) -> anyhow::Result<Instruction> {
-    let kamino_program_id = Pubkey::from_str(KAMINO_LENDING_PROGRAM_ID)?;
-    let lending_market = Pubkey::from_str(KAMINO_LENDING_MARKET)?;
-    let lending_market_authority = Pubkey::from_str(KAMINO_LENDING_MARKET_AUTHORITY)?;
-    let reserve = Pubkey::from_str(KAMINO_SOL_RESERVE)?;
-    let reserve_liquidity_mint = Pubkey::from_str(SOL_MINT)?;
-    let reserve_destination_liquidity = Pubkey::from_str(KAMINO_SOL_RESERVE_LIQUIDITY)?;
-    let fee_receiver = Pubkey::from_str(KAMINO_SOL_FEE_RECEIVER)?;
-    let referrer_token_state = Pubkey::from_str(KAMINO_REFERRER_TOKEN_STATE)?;
-    let referrer_account = Pubkey::from_str(KAMINO_REFERRER_ACCOUNT)?;
+    let kamino_program_id = KAMINO_LENDING_PROGRAM_ID;
+    let lending_market = KAMINO_LENDING_MARKET;
+    let lending_market_authority = KAMINO_LENDING_MARKET_AUTHORITY;
+    let reserve = KAMINO_SOL_RESERVE;
+    let reserve_liquidity_mint = spl_token::native_mint::id();
+    let reserve_destination_liquidity = KAMINO_SOL_RESERVE_LIQUIDITY;
+    let fee_receiver = KAMINO_SOL_FEE_RECEIVER;
+    let referrer_token_state = KAMINO_REFERRER_TOKEN_STATE;
+    let referrer_account = KAMINO_REFERRER_ACCOUNT;
 
     let accounts = vec![
         AccountMeta::new(*wallet_pk, true), // userTransferAuthority

--- a/src/pools.rs
+++ b/src/pools.rs
@@ -1,7 +1,4 @@
-use crate::{
-    constants::SOL_MINT,
-    dex::raydium::{clmm_info::POOL_TICK_ARRAY_BITMAP_SEED, raydium_clmm_program_id},
-};
+use crate::dex::raydium::{clmm_info::POOL_TICK_ARRAY_BITMAP_SEED, raydium_clmm_program_id};
 use solana_program::pubkey::Pubkey;
 use std::str::FromStr;
 
@@ -91,7 +88,7 @@ pub struct MintPoolData {
 
 impl MintPoolData {
     pub fn new(mint: &str, wallet_account: &str) -> anyhow::Result<Self> {
-        let sol_mint = Pubkey::from_str(SOL_MINT)?;
+        let sol_mint = spl_token::native_mint::id();
         let wallet_pk = Pubkey::from_str(wallet_account)?;
         let wallet_wsol_pk =
             spl_associated_token_account::get_associated_token_address(&wallet_pk, &sol_mint);
@@ -109,166 +106,136 @@ impl MintPoolData {
         })
     }
 
-    pub fn add_raydium_pool(
-        &mut self,
-        pool: &str,
-        token_vault: &str,
-        sol_vault: &str,
-    ) -> anyhow::Result<()> {
+    pub fn add_raydium_pool(&mut self, pool: &Pubkey, token_vault: &Pubkey, sol_vault: &Pubkey) {
         self.raydium_pools.push(RaydiumPool {
-            pool: Pubkey::from_str(pool)?,
-            token_vault: Pubkey::from_str(token_vault)?,
-            sol_vault: Pubkey::from_str(sol_vault)?,
+            pool: *pool,
+            token_vault: *token_vault,
+            sol_vault: *sol_vault,
         });
-        Ok(())
     }
 
     pub fn add_raydium_cp_pool(
         &mut self,
-        pool: &str,
-        token_vault: &str,
-        sol_vault: &str,
-        amm_config: &str,
-        observation: &str,
-    ) -> anyhow::Result<()> {
+        pool: &Pubkey,
+        token_vault: &Pubkey,
+        sol_vault: &Pubkey,
+        amm_config: &Pubkey,
+        observation: &Pubkey,
+    ) {
         self.raydium_cp_pools.push(RaydiumCpPool {
-            pool: Pubkey::from_str(pool)?,
-            token_vault: Pubkey::from_str(token_vault)?,
-            sol_vault: Pubkey::from_str(sol_vault)?,
-            amm_config: Pubkey::from_str(amm_config)?,
-            observation: Pubkey::from_str(observation)?,
+            pool: *pool,
+            token_vault: *token_vault,
+            sol_vault: *sol_vault,
+            amm_config: *amm_config,
+            observation: *observation,
         });
-        Ok(())
     }
 
     pub fn add_pump_pool(
         &mut self,
-        pool: &str,
-        token_vault: &str,
-        sol_vault: &str,
-        fee_token_wallet: &str,
-        coin_creator_vault_ata: &str,
-        coin_creator_authority: &str,
-    ) -> anyhow::Result<()> {
+        pool: &Pubkey,
+        token_vault: &Pubkey,
+        sol_vault: &Pubkey,
+        fee_token_wallet: &Pubkey,
+        coin_creator_vault_ata: &Pubkey,
+        coin_creator_authority: &Pubkey,
+    ) {
         self.pump_pools.push(PumpPool {
-            pool: Pubkey::from_str(pool)?,
-            token_vault: Pubkey::from_str(token_vault)?,
-            sol_vault: Pubkey::from_str(sol_vault)?,
-            fee_token_wallet: Pubkey::from_str(fee_token_wallet)?,
-            coin_creator_vault_ata: Pubkey::from_str(coin_creator_vault_ata)?,
-            coin_creator_vault_authority: Pubkey::from_str(coin_creator_authority)?,
-        });
-        Ok(())
+            pool: *pool,
+            token_vault: *token_vault,
+            sol_vault: *sol_vault,
+            fee_token_wallet: *fee_token_wallet,
+            coin_creator_vault_ata: *coin_creator_vault_ata,
+            coin_creator_vault_authority: *coin_creator_authority,
+        })
     }
 
     pub fn add_dlmm_pool(
         &mut self,
-        pair: &str,
-        token_vault: &str,
-        sol_vault: &str,
-        oracle: &str,
-        bin_arrays: Vec<&str>,
-    ) -> anyhow::Result<()> {
-        let bin_array_pubkeys = bin_arrays
-            .iter()
-            .map(|&s| Pubkey::from_str(s))
-            .collect::<Result<Vec<_>, _>>()?;
-
+        pair: &Pubkey,
+        token_vault: &Pubkey,
+        sol_vault: &Pubkey,
+        oracle: &Pubkey,
+        bin_array_pubkeys: &[Pubkey],
+    ) {
         self.dlmm_pairs.push(DlmmPool {
-            pair: Pubkey::from_str(pair)?,
-            token_vault: Pubkey::from_str(token_vault)?,
-            sol_vault: Pubkey::from_str(sol_vault)?,
-            oracle: Pubkey::from_str(oracle)?,
-            bin_arrays: bin_array_pubkeys,
+            pair: *pair,
+            token_vault: *token_vault,
+            sol_vault: *sol_vault,
+            oracle: *oracle,
+            bin_arrays: bin_array_pubkeys.to_vec(),
         });
-        Ok(())
     }
 
     pub fn add_whirlpool_pool(
         &mut self,
-        pool: &str,
-        oracle: &str,
-        x_vault: &str,
-        y_vault: &str,
-        tick_arrays: Vec<&str>,
-    ) -> anyhow::Result<()> {
-        let tick_array_pubkeys = tick_arrays
-            .iter()
-            .map(|&s| Pubkey::from_str(s))
-            .collect::<Result<Vec<_>, _>>()?;
-
+        pool: &Pubkey,
+        oracle: &Pubkey,
+        x_vault: &Pubkey,
+        y_vault: &Pubkey,
+        tick_arrays: &[Pubkey],
+    ) {
         self.whirlpool_pools.push(WhirlpoolPool {
-            pool: Pubkey::from_str(pool)?,
-            oracle: Pubkey::from_str(oracle)?,
-            x_vault: Pubkey::from_str(x_vault)?,
-            y_vault: Pubkey::from_str(y_vault)?,
-            tick_arrays: tick_array_pubkeys,
+            pool: *pool,
+            oracle: *oracle,
+            x_vault: *x_vault,
+            y_vault: *y_vault,
+            tick_arrays: tick_arrays.to_vec(),
         });
-        Ok(())
     }
 
     pub fn add_raydium_clmm_pool(
         &mut self,
-        pool: &str,
-        amm_config: &str,
-        observation_state: &str,
-        x_vault: &str,
-        y_vault: &str,
-        tick_arrays: Vec<&str>,
-    ) -> anyhow::Result<()> {
-        let pool_pubkey = Pubkey::from_str(pool)?;
+        pool: &Pubkey,
+        amm_config: &Pubkey,
+        observation_state: &Pubkey,
+        x_vault: &Pubkey,
+        y_vault: &Pubkey,
+        tick_arrays: &[Pubkey],
+    ) {
         let bitmap_extension = Pubkey::find_program_address(
-            &[
-                POOL_TICK_ARRAY_BITMAP_SEED.as_bytes(),
-                &pool_pubkey.as_ref(),
-            ],
+            &[POOL_TICK_ARRAY_BITMAP_SEED.as_bytes(), pool.as_ref()],
             &raydium_clmm_program_id(),
         )
         .0;
-        let tick_array_pubkeys = tick_arrays
-            .iter()
-            .map(|&s| Pubkey::from_str(s))
-            .collect::<Result<Vec<_>, _>>()?;
 
         self.raydium_clmm_pools.push(RaydiumClmmPool {
-            pool: pool_pubkey,
-            amm_config: Pubkey::from_str(amm_config)?,
-            observation_state: Pubkey::from_str(observation_state)?,
-            x_vault: Pubkey::from_str(x_vault)?,
-            y_vault: Pubkey::from_str(y_vault)?,
+            pool: *pool,
+            amm_config: *amm_config,
+            observation_state: *observation_state,
+            x_vault: *x_vault,
+            y_vault: *y_vault,
             bitmap_extension,
-            tick_arrays: tick_array_pubkeys,
+            tick_arrays: tick_arrays.to_vec(),
         });
-        Ok(())
     }
 
     pub fn add_meteora_damm_pool(
         &mut self,
-        pool: &str,
-        token_x_vault: &str,
-        token_sol_vault: &str,
-        token_x_token_vault: &str,
-        token_sol_token_vault: &str,
-        token_x_lp_mint: &str,
-        token_sol_lp_mint: &str,
-        token_x_pool_lp: &str,
-        token_sol_pool_lp: &str,
-        admin_token_fee_x: &str,
-        admin_token_fee_sol: &str,
-    ) -> anyhow::Result<()> {
+        pool: &Pubkey,
+        token_x_vault: &Pubkey,
+        token_sol_vault: &Pubkey,
+        token_x_token_vault: &Pubkey,
+        token_sol_token_vault: &Pubkey,
+        token_x_lp_mint: &Pubkey,
+        token_sol_lp_mint: &Pubkey,
+        token_x_pool_lp: &Pubkey,
+        token_sol_pool_lp: &Pubkey,
+        admin_token_fee_x: &Pubkey,
+        admin_token_fee_sol: &Pubkey,
+    ) {
         self.meteora_damm_pools.push(MeteoraDAmmPool {
-            pool: Pubkey::from_str(pool)?,
-            token_x_vault: Pubkey::from_str(token_x_vault)?,
-            token_sol_vault: Pubkey::from_str(token_sol_vault)?,
-            token_x_token_vault: Pubkey::from_str(token_x_token_vault)?,
-            token_sol_token_vault: Pubkey::from_str(token_sol_token_vault)?,
-            token_x_lp_mint: Pubkey::from_str(token_x_lp_mint)?,
-            token_sol_lp_mint: Pubkey::from_str(token_sol_lp_mint)?,
-            token_x_pool_lp: Pubkey::from_str(token_x_pool_lp)?,
-            token_sol_pool_lp: Pubkey::from_str(token_sol_pool_lp)?,
-            admin_token_fee_x: Pubkey::from_str(admin_token_fee_x)?,
-            admin_token_fee_sol: Pubkey::from_str(admin_token_fee_sol)?,
-        });
-        Ok(())
+            pool: *pool,
+            token_x_vault: *token_x_vault,
+            token_sol_vault: *token_sol_vault,
+            token_x_token_vault: *token_x_token_vault,
+            token_sol_token_vault: *token_sol_token_vault,
+            token_x_lp_mint: *token_x_lp_mint,
+            token_sol_lp_mint: *token_sol_lp_mint,
+            token_x_pool_lp: *token_x_pool_lp,
+            token_sol_pool_lp: *token_sol_pool_lp,
+            admin_token_fee_x: *admin_token_fee_x,
+            admin_token_fee_sol: *admin_token_fee_sol,
+        })
     }
 }

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -12,7 +12,6 @@ use crate::dex::whirlpool::{
 use crate::pools::*;
 use solana_client::rpc_client::RpcClient;
 use solana_program::pubkey::Pubkey;
-use spl_associated_token_account;
 use std::str::FromStr;
 use std::sync::Arc;
 use tracing::{error, info};
@@ -81,26 +80,23 @@ pub async fn initialize_pool_data(
                                 );
 
                             pool_data.add_pump_pool(
-                                pool_address,
-                                &token_vault.to_string(),
-                                &sol_vault.to_string(),
-                                &fee_token_wallet.to_string(),
-                                &coin_creator_vault_ata.to_string(),
-                                &amm_info.coin_creator_vault_authority.to_string(),
-                            )?;
-                            info!("Pump pool added: {}", pool_address);
-                            info!("    Base mint: {}", amm_info.base_mint.to_string());
-                            info!("    Quote mint: {}", amm_info.quote_mint.to_string());
-                            info!("    Token vault: {}", token_vault.to_string());
-                            info!("    Sol vault: {}", sol_vault.to_string());
-                            info!("    Fee token wallet: {}", fee_token_wallet.to_string());
-                            info!(
-                                "    Coin creator vault ata: {}",
-                                coin_creator_vault_ata.to_string()
+                                &pump_pool_pubkey,
+                                &token_vault,
+                                &sol_vault,
+                                &fee_token_wallet,
+                                &coin_creator_vault_ata,
+                                &amm_info.coin_creator_vault_authority,
                             );
+                            info!("Pump pool added: {}", pool_address);
+                            info!("    Base mint: {}", amm_info.base_mint);
+                            info!("    Quote mint: {}", amm_info.quote_mint);
+                            info!("    Token vault: {}", token_vault);
+                            info!("    Sol vault: {}", sol_vault);
+                            info!("    Fee token wallet: {}", fee_token_wallet);
+                            info!("    Coin creator vault ata: {}", coin_creator_vault_ata);
                             info!(
                                 "    Coin creator vault authority: {}",
-                                amm_info.coin_creator_vault_authority.to_string()
+                                amm_info.coin_creator_vault_authority
                             );
                             info!("    Initialized Pump pool: {}\n", pump_pool_pubkey);
                         }
@@ -173,15 +169,15 @@ pub async fn initialize_pool_data(
                             };
 
                             pool_data.add_raydium_pool(
-                                pool_address,
-                                &token_vault.to_string(),
-                                &sol_vault.to_string(),
-                            )?;
-                            info!("Raydium pool added: {}", pool_address);
-                            info!("    Coin mint: {}", amm_info.coin_mint.to_string());
-                            info!("    PC mint: {}", amm_info.pc_mint.to_string());
-                            info!("    Token vault: {}", token_vault.to_string());
-                            info!("    Sol vault: {}", sol_vault.to_string());
+                                &raydium_pool_pubkey,
+                                &token_vault,
+                                &sol_vault,
+                            );
+                            info!("Raydium pool added: {}", raydium_pool_pubkey);
+                            info!("    Coin mint: {}", amm_info.coin_mint);
+                            info!("    PC mint: {}", amm_info.pc_mint);
+                            info!("    Token vault: {}", token_vault);
+                            info!("    Sol vault: {}", sol_vault);
                             info!("    Initialized Raydium pool: {}\n", raydium_pool_pubkey);
                         }
                         Err(e) => {
@@ -251,20 +247,17 @@ pub async fn initialize_pool_data(
                             };
 
                             pool_data.add_raydium_cp_pool(
-                                pool_address,
-                                &token_vault.to_string(),
-                                &sol_vault.to_string(),
-                                &amm_info.amm_config.to_string(),
-                                &amm_info.observation_key.to_string(),
-                            )?;
-                            info!("Raydium CP pool added: {}", pool_address);
-                            info!("    Token vault: {}", token_vault.to_string());
-                            info!("    Sol vault: {}", sol_vault.to_string());
-                            info!("    AMM Config: {}", amm_info.amm_config.to_string());
-                            info!(
-                                "    Observation Key: {}\n",
-                                amm_info.observation_key.to_string()
+                                &raydium_cp_pool_pubkey,
+                                &token_vault,
+                                &sol_vault,
+                                &amm_info.amm_config,
+                                &amm_info.observation_key,
                             );
+                            info!("Raydium CP pool added: {}", raydium_cp_pool_pubkey);
+                            info!("    Token vault: {}", token_vault);
+                            info!("    Sol vault: {}", sol_vault);
+                            info!("    AMM Config: {}", amm_info.amm_config);
+                            info!("    Observation Key: {}\n", amm_info.observation_key);
                         }
                         Err(e) => {
                             error!(
@@ -319,28 +312,23 @@ pub async fn initialize_pool_data(
                                 }
                             };
 
-                            let bin_array_strings: Vec<String> =
-                                bin_arrays.iter().map(|pubkey| pubkey.to_string()).collect();
-                            let bin_array_str_refs: Vec<&str> =
-                                bin_array_strings.iter().map(|s| s.as_str()).collect();
-
                             pool_data.add_dlmm_pool(
-                                pool_address,
-                                &token_vault.to_string(),
-                                &sol_vault.to_string(),
-                                &amm_info.oracle.to_string(),
-                                bin_array_str_refs,
-                            )?;
+                                &dlmm_pool_pubkey,
+                                &token_vault,
+                                &sol_vault,
+                                &amm_info.oracle,
+                                &bin_arrays,
+                            );
 
                             info!("DLMM pool added: {}", pool_address);
-                            info!("    Token X Mint: {}", amm_info.token_x_mint.to_string());
-                            info!("    Token Y Mint: {}", amm_info.token_y_mint.to_string());
-                            info!("    Token vault: {}", token_vault.to_string());
-                            info!("    Sol vault: {}", sol_vault.to_string());
-                            info!("    Oracle: {}", amm_info.oracle.to_string());
+                            info!("    Token X Mint: {}", amm_info.token_x_mint);
+                            info!("    Token Y Mint: {}", amm_info.token_y_mint);
+                            info!("    Token vault: {}", token_vault);
+                            info!("    Sol vault: {}", sol_vault);
+                            info!("    Oracle: {}", amm_info.oracle);
                             info!("    Active ID: {}", amm_info.active_id);
 
-                            for (i, array) in bin_array_strings.iter().enumerate() {
+                            for (i, array) in bin_arrays.iter().enumerate() {
                                 info!("    Bin Array {}: {}", i, array);
                             }
                             info!("");
@@ -424,30 +412,27 @@ pub async fn initialize_pool_data(
                                 &whirlpool_program_id(),
                             );
 
-                            let tick_array_strings: Vec<String> = whirlpool_tick_arrays
+                            let tick_arrays: Vec<Pubkey> = whirlpool_tick_arrays
                                 .iter()
-                                .map(|meta| meta.pubkey.to_string())
+                                .map(|meta| meta.pubkey)
                                 .collect();
 
-                            let tick_array_str_refs: Vec<&str> =
-                                tick_array_strings.iter().map(|s| s.as_str()).collect();
-
                             pool_data.add_whirlpool_pool(
-                                pool_address,
-                                &whirlpool_oracle.to_string(),
-                                &token_vault.to_string(),
-                                &sol_vault.to_string(),
-                                tick_array_str_refs,
-                            )?;
+                                &whirlpool_pool_pubkey,
+                                &whirlpool_oracle,
+                                &token_vault,
+                                &sol_vault,
+                                &tick_arrays,
+                            );
 
                             info!("Whirlpool pool added: {}", pool_address);
-                            info!("    Token mint A: {}", whirlpool.token_mint_a.to_string());
-                            info!("    Token mint B: {}", whirlpool.token_mint_b.to_string());
-                            info!("    Token vault: {}", token_vault.to_string());
-                            info!("    Sol vault: {}", sol_vault.to_string());
-                            info!("    Oracle: {}", whirlpool_oracle.to_string());
+                            info!("    Token mint A: {}", whirlpool.token_mint_a);
+                            info!("    Token mint B: {}", whirlpool.token_mint_b);
+                            info!("    Token vault: {}", token_vault);
+                            info!("    Sol vault: {}", sol_vault);
+                            info!("    Oracle: {}", whirlpool_oracle);
 
-                            for (i, array) in tick_array_strings.iter().enumerate() {
+                            for (i, array) in tick_arrays.iter().enumerate() {
                                 info!("    Tick Array {}: {}", i, array);
                             }
                             info!("");
@@ -475,8 +460,9 @@ pub async fn initialize_pool_data(
     if let Some(pools) = raydium_clmm_pools {
         for pool_address in pools {
             let raydium_clmm_program_id = raydium_clmm_program_id();
+            let clmm_pool_pubkey = Pubkey::from_str(pool_address)?;
 
-            match rpc_client.get_account(&Pubkey::from_str(pool_address)?) {
+            match rpc_client.get_account(&clmm_pool_pubkey) {
                 Ok(account) => {
                     if account.owner != raydium_clmm_program_id {
                         error!(
@@ -517,41 +503,24 @@ pub async fn initialize_pool_data(
                                 &raydium_clmm_program_id,
                             )?;
 
-                            let tick_array_strings: Vec<String> = tick_array_pubkeys
-                                .iter()
-                                .map(|pubkey| pubkey.to_string())
-                                .collect();
-
-                            let tick_array_str_refs: Vec<&str> =
-                                tick_array_strings.iter().map(|s| s.as_str()).collect();
-
                             pool_data.add_raydium_clmm_pool(
-                                pool_address,
-                                &raydium_clmm.amm_config.to_string(),
-                                &raydium_clmm.observation_key.to_string(),
-                                &token_vault.to_string(),
-                                &sol_vault.to_string(),
-                                tick_array_str_refs,
-                            )?;
+                                &clmm_pool_pubkey,
+                                &raydium_clmm.amm_config,
+                                &raydium_clmm.observation_key,
+                                &token_vault,
+                                &sol_vault,
+                                &tick_array_pubkeys,
+                            );
 
                             info!("Raydium CLMM pool added: {}", pool_address);
-                            info!(
-                                "    Token mint 0: {}",
-                                raydium_clmm.token_mint_0.to_string()
-                            );
-                            info!(
-                                "    Token mint 1: {}",
-                                raydium_clmm.token_mint_1.to_string()
-                            );
-                            info!("    Token vault: {}", token_vault.to_string());
-                            info!("    Sol vault: {}", sol_vault.to_string());
-                            info!("    AMM config: {}", raydium_clmm.amm_config.to_string());
-                            info!(
-                                "    Observation key: {}",
-                                raydium_clmm.observation_key.to_string()
-                            );
+                            info!("    Token mint 0: {}", raydium_clmm.token_mint_0);
+                            info!("    Token mint 1: {}", raydium_clmm.token_mint_1);
+                            info!("    Token vault: {}", token_vault);
+                            info!("    Sol vault: {}", sol_vault);
+                            info!("    AMM config: {}", raydium_clmm.amm_config);
+                            info!("    Observation key: {}", raydium_clmm.observation_key);
 
-                            for (i, array) in tick_array_strings.iter().enumerate() {
+                            for (i, array) in tick_array_pubkeys.iter().enumerate() {
                                 info!("    Tick Array {}: {}", i, array);
                             }
                             info!("");
@@ -630,10 +599,10 @@ pub async fn initialize_pool_data(
                             let sol_vault_data = rpc_client.get_account(&sol_vault)?;
 
                             let x_vault_obj = meteora_vault_cpi::Vault::deserialize_unchecked(
-                                &mut x_vault_data.data.as_slice(),
+                                x_vault_data.data.as_slice(),
                             )?;
                             let sol_vault_obj = meteora_vault_cpi::Vault::deserialize_unchecked(
-                                &mut sol_vault_data.data.as_slice(),
+                                sol_vault_data.data.as_slice(),
                             )?;
 
                             let x_token_vault = x_vault_obj.token_vault;
@@ -654,28 +623,28 @@ pub async fn initialize_pool_data(
                             };
 
                             pool_data.add_meteora_damm_pool(
-                                pool_address,
-                                &x_vault.to_string(),
-                                &sol_vault.to_string(),
-                                &x_token_vault.to_string(),
-                                &sol_token_vault.to_string(),
-                                &x_lp_mint.to_string(),
-                                &sol_lp_mint.to_string(),
-                                &x_pool_lp.to_string(),
-                                &sol_pool_lp.to_string(),
-                                &x_admin_fee.to_string(),
-                                &sol_admin_fee.to_string(),
-                            )?;
+                                &meteora_damm_pool_pubkey,
+                                &x_vault,
+                                &sol_vault,
+                                &x_token_vault,
+                                &sol_token_vault,
+                                &x_lp_mint,
+                                &sol_lp_mint,
+                                &x_pool_lp,
+                                &sol_pool_lp,
+                                &x_admin_fee,
+                                &sol_admin_fee,
+                            );
 
                             info!("Meteora DAMM pool added: {}", pool_address);
-                            info!("    Token X vault: {}", x_token_vault.to_string());
-                            info!("    SOL vault: {}", sol_token_vault.to_string());
-                            info!("    Token X LP mint: {}", x_lp_mint.to_string());
-                            info!("    SOL LP mint: {}", sol_lp_mint.to_string());
-                            info!("    Token X pool LP: {}", x_pool_lp.to_string());
-                            info!("    SOL pool LP: {}", sol_pool_lp.to_string());
-                            info!("    Token X admin fee: {}", x_admin_fee.to_string());
-                            info!("    SOL admin fee: {}", sol_admin_fee.to_string());
+                            info!("    Token X vault: {}", x_token_vault);
+                            info!("    SOL vault: {}", sol_token_vault);
+                            info!("    Token X LP mint: {}", x_lp_mint);
+                            info!("    SOL LP mint: {}", sol_lp_mint);
+                            info!("    Token X pool LP: {}", x_pool_lp);
+                            info!("    SOL pool LP: {}", sol_pool_lp);
+                            info!("    Token X admin fee: {}", x_admin_fee);
+                            info!("    SOL admin fee: {}", sol_admin_fee);
                             info!("");
                         }
                         Err(e) => {


### PR DESCRIPTION
## Problem
a lot of unnecessary transformations from `Pubkey` to `String` and vice versa
which leads to worse run-time speed and extra memory usage

## Solution
remove those extra-steps