### PR TITLE
Add support for Vertigo pools in the Mint configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ https://solscan.io/tx/2JtgbXAgwPib9L5Ruc5vLhQ5qeX5EMhVDQbcCaAYVJKpEFn22ArEqXhipu
 - Raydium CLMM
 - Meteora DLMM
 - Meteora Dynamic AMM
+- Meteora DAMM V2
 - Orca Whirlpool
+- SolFi
+- Vertigo
 
 ## Getting Started
 
@@ -82,10 +85,13 @@ https://solscan.io/tx/2JtgbXAgwPib9L5Ruc5vLhQ5qeX5EMhVDQbcCaAYVJKpEFn22ArEqXhipu
   - `raydium_pool_list`: List of Raydium pool addresses
   - `meteora_damm_pool_list`: List of Meteora Dynamic AMM pool addresses
   - `meteora_dlmm_pool_list`: List of Meteora DLMM pool addresses
+  - `meteora_damm_v2_pool_list`: List of Meteora DAMM V2 pool addresses
   - `raydium_cp_pool_list`: List of Raydium CP pool addresses
   - `pump_pool_list`: List of Pump pool addresses
   - `whirlpool_pool_list`: List of Whirlpool pool addresses
   - `raydium_clmm_pool_list`: List of Raydium CLMM pool addresses
+  - `solfi_pool_list`: List of Solfi pool addresses
+  - `vertigo_pool_list`: List of Vertigo pool addresses
   - `lookup_table_accounts`: List of lookup table accounts
   - `process_delay`: Process delay in milliseconds
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -10,11 +10,13 @@ compute_unit_limit = 600000
 mint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"                # USDC
 pump_pool_list = ["Gf7sXMoP8iRw4iiXmJ1nq4vxcRycbGXy5RL8a8LnTd3v"]
 raydium_pool_list = ["58oQChx4yWmvKdwLLZzBi4ChoCc2fqCUWBkwMihLYQo2"]
-# meteora_damm_pool_list = ["5yuefgbJJpmFNK2iiYbLSpv1aZXq7F9AUKkZKErTYCvs"]
+meteora_damm_pool_list = []
 meteora_dlmm_pool_list = ["5rCf1DM8LjKTw4YqhnoLcngyZYeNnQqztScTogYHAS6"]
+meteora_damm_v2_pool_list = []
 whirlpool_pool_list = ["Czfq3xZZDmsdGdUyrNLtRhGc47cXcZtLG4crryfu44zE"]
 raydium_clmm_pool_list = ["3ucNos4NbumPLZNWztqGHNFFgkHeRMBQAVemeeomsUxv"]
 raydium_cp_pool_list = []
+vertigo_pool_list = [] 
 lookup_table_accounts = ["8HvgxVyd22Jq9mmoojm4Awqw6sbymbF5pwLr8FtvySHs"]
 process_delay = 400
 

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -126,6 +126,7 @@ pub async fn run_bot(config_path: &str) -> anyhow::Result<()> {
             mint_config.meteora_damm_pool_list.as_ref(),
             mint_config.solfi_pool_list.as_ref(),
             mint_config.meteora_damm_v2_pool_list.as_ref(),
+            mint_config.vertigo_pool_list.as_ref(),
             rpc_client.clone(),
         )
         .await?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,8 @@ pub struct MintConfig {
 
     pub solfi_pool_list: Option<Vec<String>>,
 
+    pub vertigo_pool_list: Option<Vec<String>>,
+
     pub lookup_table_accounts: Option<Vec<String>>,
     pub process_delay: u64,
 }

--- a/src/dex/mod.rs
+++ b/src/dex/mod.rs
@@ -2,4 +2,5 @@ pub mod meteora;
 pub mod pump;
 pub mod raydium;
 pub mod solfi;
+pub mod vertigo;
 pub mod whirlpool;

--- a/src/dex/vertigo/constants.rs
+++ b/src/dex/vertigo/constants.rs
@@ -1,0 +1,7 @@
+use solana_program::pubkey::Pubkey;
+use std::str::FromStr;
+
+// TODO: Replace with actual Vertigo program ID once available
+pub fn vertigo_program_id() -> Pubkey {
+    Pubkey::from_str("vrTGoBuy5rYSxAfV3jaRJWHH6nN9WK4NRExGxsk1bCJ").unwrap()
+}

--- a/src/dex/vertigo/info.rs
+++ b/src/dex/vertigo/info.rs
@@ -1,0 +1,61 @@
+use anyhow::Result;
+use borsh::{BorshDeserialize, BorshSerialize};
+use solana_program::pubkey::Pubkey;
+
+#[derive(Debug, BorshDeserialize, BorshSerialize)]
+pub struct VertigoPool {
+    pub mint_a: Pubkey,
+    pub mint_b: Pubkey,
+    pub owner: Pubkey,
+    // Add other fields as needed based on actual Vertigo pool structure
+}
+
+impl VertigoPool {
+    pub fn try_deserialize(data: &mut &[u8]) -> Result<Self> {
+        Self::try_from_slice(data)
+            .map_err(|e| anyhow::anyhow!("Failed to deserialize VertigoPool: {}", e))
+    }
+}
+
+#[derive(Debug)]
+pub struct VertigoInfo {
+    pub mint_a: Pubkey,
+    pub mint_b: Pubkey,
+    pub owner: Pubkey,
+}
+
+impl VertigoInfo {
+    pub fn load_checked(data: &[u8]) -> Result<Self> {
+        let mut data_slice = &data[..];
+        let vertigo_pool = VertigoPool::try_deserialize(&mut data_slice)?;
+
+        Ok(Self {
+            mint_a: vertigo_pool.mint_a,
+            mint_b: vertigo_pool.mint_b,
+            owner: vertigo_pool.owner,
+        })
+    }
+
+    pub fn get_token_and_sol_vaults(&self, base_mint: &str, sol_mint: &Pubkey) -> (Pubkey, Pubkey) {
+        let token_x_vault = if base_mint == self.mint_a.to_string() {
+            derive_vault_address(&self.owner, &self.mint_b).0
+        } else {
+            derive_vault_address(&self.owner, &self.mint_a).0
+        };
+
+        let token_base_vault = if base_mint == self.mint_a.to_string() {
+            derive_vault_address(&self.owner, &self.mint_a).0
+        } else {
+            derive_vault_address(&self.owner, &self.mint_b).0
+        };
+
+        (token_x_vault, token_base_vault)
+    }
+}
+
+/// Helper function to derive vault PDA
+pub fn derive_vault_address(pool: &Pubkey, mint: &Pubkey) -> (Pubkey, u8) {
+    use crate::dex::vertigo::constants::vertigo_program_id;
+
+    Pubkey::find_program_address(&[pool.as_ref(), mint.as_ref()], &vertigo_program_id())
+}

--- a/src/dex/vertigo/mod.rs
+++ b/src/dex/vertigo/mod.rs
@@ -1,0 +1,5 @@
+pub mod constants;
+pub mod info;
+
+pub use constants::*;
+pub use info::*;


### PR DESCRIPTION
- Introduced `vertigo_pool_list` in the `MintConfig` struct to manage Vertigo pools.
- Added `VertigoPool` struct to represent Vertigo pool data.
- Updated `MintPoolData` to include methods for adding and initializing Vertigo pools.
- Enhanced `initialize_pool_data` to fetch and validate Vertigo pool accounts.
- Updated transaction creation logic to include Vertigo pool accounts and memo program support.
- Modified README.md to document the new Vertigo pool configuration.