### PR TITLE
Add support for Futarchy, Humidifi, PancakeSwap, and Byreal pools

### DIFF
--- a/src/dex/byreal/mod.rs
+++ b/src/dex/byreal/mod.rs
@@ -1,0 +1,10 @@
+use solana_program::pubkey::Pubkey;
+use std::str::FromStr;
+
+pub fn byreal_program_id() -> Pubkey {
+    Pubkey::from_str("REALQqNEomY6cQGZJUGwywTBD2UmDT32rZcNnfxQ5N2").unwrap()
+}
+
+pub fn byreal_authority() -> Pubkey {
+    Pubkey::from_str("GThUX1Atko4tqhN2NaiTazWSeFWMuiUvfFnyJyUghFMJ").unwrap()
+}

--- a/src/dex/futarchy/info.rs
+++ b/src/dex/futarchy/info.rs
@@ -1,0 +1,45 @@
+use anyhow::Result;
+use solana_program::pubkey::Pubkey;
+
+// Byte offsets for Futarchy DAO account parsing
+// Reference: ~/solana/arb-bot-rust/programs/executor-pinocchio/src/futarchy.rs
+const BASE_MINT_OFFSET: usize = 157;
+const QUOTE_MINT_OFFSET: usize = 189;
+const BASE_VAULT_OFFSET: usize = 221;
+const QUOTE_VAULT_OFFSET: usize = 253;
+
+pub struct FutarchyInfo {
+    pub base_mint: Pubkey,
+    pub quote_mint: Pubkey,
+    pub base_vault: Pubkey,
+    pub quote_vault: Pubkey,
+}
+
+impl FutarchyInfo {
+    pub fn load_checked(data: &[u8]) -> Result<Self> {
+        if data.len() < QUOTE_VAULT_OFFSET + 32 {
+            return Err(anyhow::anyhow!("Invalid data length for FutarchyInfo"));
+        }
+
+        let base_mint = read_pubkey(data, BASE_MINT_OFFSET)?;
+        let quote_mint = read_pubkey(data, QUOTE_MINT_OFFSET)?;
+        let base_vault = read_pubkey(data, BASE_VAULT_OFFSET)?;
+        let quote_vault = read_pubkey(data, QUOTE_VAULT_OFFSET)?;
+
+        Ok(Self {
+            base_mint,
+            quote_mint,
+            base_vault,
+            quote_vault,
+        })
+    }
+}
+
+fn read_pubkey(data: &[u8], offset: usize) -> Result<Pubkey> {
+    if data.len() < offset + 32 {
+        return Err(anyhow::anyhow!("Data too short to read pubkey at offset {}", offset));
+    }
+    let mut bytes = [0u8; 32];
+    bytes.copy_from_slice(&data[offset..offset + 32]);
+    Ok(Pubkey::new_from_array(bytes))
+}

--- a/src/dex/futarchy/mod.rs
+++ b/src/dex/futarchy/mod.rs
@@ -1,0 +1,10 @@
+pub mod info;
+
+pub use info::*;
+
+use solana_program::pubkey::Pubkey;
+use std::str::FromStr;
+
+pub fn futarchy_program_id() -> Pubkey {
+    Pubkey::from_str("FUTARELBfJfQ8RDGhg1wdhddq1odMAJUePHFuBYfUxKq").unwrap()
+}

--- a/src/dex/humidifi/info.rs
+++ b/src/dex/humidifi/info.rs
@@ -1,0 +1,75 @@
+use anyhow::Result;
+use solana_program::pubkey::Pubkey;
+
+// Reference: ~/solana/arb-bot-rust/lib/dex-humidifi/src/pool_decoder.rs
+
+// XOR keys for decoding pubkeys stored in pool data.
+// Each 32-byte pubkey is split into 4 x 8-byte chunks, each XOR'd with corresponding key.
+const XOR_KEYS: [u64; 4] = [
+    0xfb5c_e87a_ae44_3c38,
+    0x04a2_1784_51ba_c3c7,
+    0x04a1_1787_51b9_c3c6,
+    0x04a0_1786_51b8_c3c5,
+];
+
+// Offsets for XOR-encoded pubkeys
+const QUOTE_MINT_OFFSET: usize = 0x180;
+const BASE_MINT_OFFSET: usize = 0x1a0;
+const QUOTE_VAULT_OFFSET: usize = 0x1c0;
+const BASE_VAULT_OFFSET: usize = 0x1e0;
+
+pub struct HumidifiInfo {
+    pub base_mint: Pubkey,
+    pub quote_mint: Pubkey,
+    pub base_vault: Pubkey,
+    pub quote_vault: Pubkey,
+}
+
+impl HumidifiInfo {
+    pub fn load_checked(data: &[u8]) -> Result<Self> {
+        if data.len() < BASE_VAULT_OFFSET + 32 {
+            return Err(anyhow::anyhow!("Invalid data length for HumidifiInfo"));
+        }
+
+        let quote_mint = decode_pubkey(data, QUOTE_MINT_OFFSET)
+            .ok_or_else(|| anyhow::anyhow!("Failed to decode quote_mint"))?;
+        let base_mint = decode_pubkey(data, BASE_MINT_OFFSET)
+            .ok_or_else(|| anyhow::anyhow!("Failed to decode base_mint"))?;
+        let quote_vault = decode_pubkey(data, QUOTE_VAULT_OFFSET)
+            .ok_or_else(|| anyhow::anyhow!("Failed to decode quote_vault"))?;
+        let base_vault = decode_pubkey(data, BASE_VAULT_OFFSET)
+            .ok_or_else(|| anyhow::anyhow!("Failed to decode base_vault"))?;
+
+        Ok(Self {
+            base_mint,
+            quote_mint,
+            base_vault,
+            quote_vault,
+        })
+    }
+}
+
+/// Decode a 32-byte pubkey from XOR-encoded pool data.
+/// Each pubkey is stored as 4 consecutive u64 values, each XOR'd with a key.
+fn decode_pubkey(pool_data: &[u8], offset: usize) -> Option<Pubkey> {
+    if pool_data.len() < offset + 32 {
+        return None;
+    }
+    let mut result = [0u8; 32];
+    for i in 0..4 {
+        let chunk_offset = offset + (i * 8);
+        let chunk = read_u64_le(pool_data, chunk_offset)?;
+        let decoded = chunk ^ XOR_KEYS[i];
+        result[i * 8..(i + 1) * 8].copy_from_slice(&decoded.to_le_bytes());
+    }
+    Some(Pubkey::new_from_array(result))
+}
+
+fn read_u64_le(data: &[u8], offset: usize) -> Option<u64> {
+    if data.len() < offset + 8 {
+        return None;
+    }
+    let mut bytes = [0u8; 8];
+    bytes.copy_from_slice(&data[offset..offset + 8]);
+    Some(u64::from_le_bytes(bytes))
+}

--- a/src/dex/humidifi/mod.rs
+++ b/src/dex/humidifi/mod.rs
@@ -1,0 +1,10 @@
+pub mod info;
+
+pub use info::*;
+
+use solana_program::pubkey::Pubkey;
+use std::str::FromStr;
+
+pub fn humidifi_program_id() -> Pubkey {
+    Pubkey::from_str("9H6tua7jkLhdm3w8BvgpTn5LZNU7g4ZynDmCiNN3q6Rp").unwrap()
+}

--- a/src/dex/mod.rs
+++ b/src/dex/mod.rs
@@ -1,5 +1,9 @@
+pub mod byreal;
+pub mod futarchy;
 pub mod heaven;
+pub mod humidifi;
 pub mod meteora;
+pub mod pancakeswap;
 pub mod pump;
 pub mod raydium;
 pub mod vertigo;

--- a/src/dex/pancakeswap/mod.rs
+++ b/src/dex/pancakeswap/mod.rs
@@ -1,0 +1,10 @@
+use solana_program::pubkey::Pubkey;
+use std::str::FromStr;
+
+pub fn pancakeswap_program_id() -> Pubkey {
+    Pubkey::from_str("HpNfyc2Saw7RKkQd8nEL4khUcuPhQ7WwY1B2qjx8jxFq").unwrap()
+}
+
+pub fn pancakeswap_authority() -> Pubkey {
+    Pubkey::from_str("GThUX1Atko4tqhN2NaiTazWSeFWMuiUvfFnyJyUghFMJ").unwrap()
+}

--- a/src/pools.rs
+++ b/src/pools.rs
@@ -1,7 +1,13 @@
 use crate::{
     constants::sol_mint,
-    dex::raydium::{clmm_info::POOL_TICK_ARRAY_BITMAP_SEED, raydium_clmm_program_id},
+    dex::{
+        byreal::byreal_program_id,
+        pancakeswap::pancakeswap_program_id,
+        raydium::{clmm_info::POOL_TICK_ARRAY_BITMAP_SEED, raydium_clmm_program_id},
+    },
 };
+
+const POOL_TICK_ARRAY_BITMAP_SEED_CLMM: &str = "pool_tick_array_bitmap_extension";
 use solana_program::instruction::AccountMeta;
 use solana_program::pubkey::Pubkey;
 
@@ -125,6 +131,52 @@ pub struct HeavenPool {
 }
 
 #[derive(Debug, Clone)]
+pub struct FutarchyPool {
+    pub dao: Pubkey,
+    pub token_x_vault: Pubkey,
+    pub token_sol_vault: Pubkey,
+    pub token_mint: Pubkey,
+    pub base_mint: Pubkey,
+}
+
+#[derive(Debug, Clone)]
+pub struct HumidifiPool {
+    pub pool: Pubkey,
+    pub token_x_vault: Pubkey,
+    pub token_sol_vault: Pubkey,
+    pub token_mint: Pubkey,
+    pub base_mint: Pubkey,
+}
+
+#[derive(Debug, Clone)]
+pub struct PancakeswapPool {
+    pub pool: Pubkey,
+    pub amm_config: Pubkey,
+    pub observation_state: Pubkey,
+    pub bitmap_extension: Pubkey,
+    pub x_vault: Pubkey,
+    pub y_vault: Pubkey,
+    pub tick_arrays: Vec<Pubkey>,
+    pub memo_program: Option<Pubkey>,
+    pub token_mint: Pubkey,
+    pub base_mint: Pubkey,
+}
+
+#[derive(Debug, Clone)]
+pub struct ByrealPool {
+    pub pool: Pubkey,
+    pub amm_config: Pubkey,
+    pub observation_state: Pubkey,
+    pub bitmap_extension: Pubkey,
+    pub x_vault: Pubkey,
+    pub y_vault: Pubkey,
+    pub tick_arrays: Vec<Pubkey>,
+    pub memo_program: Option<Pubkey>,
+    pub token_mint: Pubkey,
+    pub base_mint: Pubkey,
+}
+
+#[derive(Debug, Clone)]
 pub struct MintPoolData {
     pub mint: Pubkey,
     pub token_program: Pubkey, // Support for both Token and Token 2022
@@ -140,6 +192,10 @@ pub struct MintPoolData {
     pub meteora_damm_v2_pools: Vec<MeteoraDAmmV2Pool>,
     pub vertigo_pools: Vec<VertigoPool>,
     pub heaven_pools: Vec<HeavenPool>,
+    pub futarchy_pools: Vec<FutarchyPool>,
+    pub humidifi_pools: Vec<HumidifiPool>,
+    pub pancakeswap_pools: Vec<PancakeswapPool>,
+    pub byreal_pools: Vec<ByrealPool>,
 }
 
 impl MintPoolData {
@@ -162,6 +218,10 @@ impl MintPoolData {
             meteora_damm_v2_pools: Vec::new(),
             vertigo_pools: Vec::new(),
             heaven_pools: Vec::new(),
+            futarchy_pools: Vec::new(),
+            humidifi_pools: Vec::new(),
+            pancakeswap_pools: Vec::new(),
+            byreal_pools: Vec::new(),
         }
     }
 
@@ -398,6 +458,104 @@ impl MintPoolData {
             token_mint,
             base_mint,
             token_program,
+        });
+    }
+
+    pub fn add_futarchy_pool(
+        &mut self,
+        dao: Pubkey,
+        token_x_vault: Pubkey,
+        token_sol_vault: Pubkey,
+        token_mint: Pubkey,
+        base_mint: Pubkey,
+    ) {
+        self.futarchy_pools.push(FutarchyPool {
+            dao,
+            token_x_vault,
+            token_sol_vault,
+            token_mint,
+            base_mint,
+        });
+    }
+
+    pub fn add_humidifi_pool(
+        &mut self,
+        pool: Pubkey,
+        token_x_vault: Pubkey,
+        token_sol_vault: Pubkey,
+        token_mint: Pubkey,
+        base_mint: Pubkey,
+    ) {
+        self.humidifi_pools.push(HumidifiPool {
+            pool,
+            token_x_vault,
+            token_sol_vault,
+            token_mint,
+            base_mint,
+        });
+    }
+
+    pub fn add_pancakeswap_pool(
+        &mut self,
+        pool: Pubkey,
+        amm_config: Pubkey,
+        observation_state: Pubkey,
+        x_vault: Pubkey,
+        y_vault: Pubkey,
+        tick_arrays: Vec<Pubkey>,
+        memo_program: Option<Pubkey>,
+        token_mint: Pubkey,
+        base_mint: Pubkey,
+    ) {
+        let bitmap_extension = Pubkey::find_program_address(
+            &[POOL_TICK_ARRAY_BITMAP_SEED_CLMM.as_bytes(), pool.as_ref()],
+            &pancakeswap_program_id(),
+        )
+        .0;
+
+        self.pancakeswap_pools.push(PancakeswapPool {
+            pool,
+            amm_config,
+            observation_state,
+            bitmap_extension,
+            x_vault,
+            y_vault,
+            tick_arrays,
+            memo_program,
+            token_mint,
+            base_mint,
+        });
+    }
+
+    pub fn add_byreal_pool(
+        &mut self,
+        pool: Pubkey,
+        amm_config: Pubkey,
+        observation_state: Pubkey,
+        x_vault: Pubkey,
+        y_vault: Pubkey,
+        tick_arrays: Vec<Pubkey>,
+        memo_program: Option<Pubkey>,
+        token_mint: Pubkey,
+        base_mint: Pubkey,
+    ) {
+        let bitmap_extension = Pubkey::find_program_address(
+            &[POOL_TICK_ARRAY_BITMAP_SEED_CLMM.as_bytes(), pool.as_ref()],
+            &byreal_program_id(),
+        )
+        .0;
+
+        self.byreal_pools.push(ByrealPool {
+            pool,
+            amm_config,
+            observation_state,
+            bitmap_extension,
+            x_vault,
+            y_vault,
+            tick_arrays,
+            memo_program,
+            token_mint,
+            base_mint,
         });
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,6 +1,10 @@
 use crate::config::Config;
-use crate::dex::raydium::{raydium_authority, raydium_cp_authority};
+use crate::dex::byreal::byreal_program_id;
+use crate::dex::futarchy::futarchy_program_id;
 use crate::dex::heaven::constants::{heaven_program_id, heaven_protocol_account_1, heaven_protocol_account_2};
+use crate::dex::humidifi::humidifi_program_id;
+use crate::dex::pancakeswap::pancakeswap_program_id;
+use crate::dex::raydium::{raydium_authority, raydium_cp_authority};
 use crate::dex::vertigo::constants::vertigo_program_id;
 use crate::pools::MintPoolData;
 use solana_client::rpc_client::RpcClient;
@@ -477,7 +481,7 @@ fn create_swap_instruction(
         accounts.push(AccountMeta::new_readonly(pool.base_mint, false)); // V9: Add base mint
         accounts.push(AccountMeta::new(pool.pool, false));
         accounts.push(AccountMeta::new(pool.protocol_config, false)); // Protocol config is writable for Heaven
-        
+
         // Add fixed Heaven accounts
         accounts.push(AccountMeta::new_readonly(
             solana_program::sysvar::instructions::ID,
@@ -491,9 +495,63 @@ fn create_swap_instruction(
             heaven_protocol_account_2(),
             false,
         )); // Heaven protocol account 2
-        
+
         accounts.push(AccountMeta::new(pool.token_x_vault, false));
         accounts.push(AccountMeta::new(pool.token_base_vault, false));
+    }
+
+    // Add Futarchy pools
+    for pool in &mint_pool_data.futarchy_pools {
+        accounts.push(AccountMeta::new_readonly(futarchy_program_id(), false));
+        accounts.push(AccountMeta::new_readonly(pool.base_mint, false));
+        accounts.push(AccountMeta::new(pool.dao, false));
+        accounts.push(AccountMeta::new(pool.token_x_vault, false));
+        accounts.push(AccountMeta::new(pool.token_sol_vault, false));
+    }
+
+    // Add Humidifi pools
+    for pool in &mint_pool_data.humidifi_pools {
+        accounts.push(AccountMeta::new_readonly(humidifi_program_id(), false));
+        accounts.push(AccountMeta::new_readonly(pool.base_mint, false));
+        accounts.push(AccountMeta::new(pool.pool, false));
+        accounts.push(AccountMeta::new(pool.token_x_vault, false));
+        accounts.push(AccountMeta::new(pool.token_sol_vault, false));
+    }
+
+    // Add PancakeSwap pools (CLMM layout)
+    for pool in &mint_pool_data.pancakeswap_pools {
+        accounts.push(AccountMeta::new_readonly(pancakeswap_program_id(), false));
+        accounts.push(AccountMeta::new_readonly(pool.base_mint, false));
+        if let Some(memo_program) = pool.memo_program {
+            accounts.push(AccountMeta::new_readonly(memo_program, false));
+        }
+        accounts.push(AccountMeta::new(pool.pool, false));
+        accounts.push(AccountMeta::new_readonly(pool.amm_config, false));
+        accounts.push(AccountMeta::new(pool.observation_state, false));
+        accounts.push(AccountMeta::new(pool.bitmap_extension, false));
+        accounts.push(AccountMeta::new(pool.x_vault, false));
+        accounts.push(AccountMeta::new(pool.y_vault, false));
+        for tick_array in &pool.tick_arrays {
+            accounts.push(AccountMeta::new(*tick_array, false));
+        }
+    }
+
+    // Add Byreal pools (CLMM layout)
+    for pool in &mint_pool_data.byreal_pools {
+        accounts.push(AccountMeta::new_readonly(byreal_program_id(), false));
+        accounts.push(AccountMeta::new_readonly(pool.base_mint, false));
+        if let Some(memo_program) = pool.memo_program {
+            accounts.push(AccountMeta::new_readonly(memo_program, false));
+        }
+        accounts.push(AccountMeta::new(pool.pool, false));
+        accounts.push(AccountMeta::new_readonly(pool.amm_config, false));
+        accounts.push(AccountMeta::new(pool.observation_state, false));
+        accounts.push(AccountMeta::new(pool.bitmap_extension, false));
+        accounts.push(AccountMeta::new(pool.x_vault, false));
+        accounts.push(AccountMeta::new(pool.y_vault, false));
+        for tick_array in &pool.tick_arrays {
+            accounts.push(AccountMeta::new(*tick_array, false));
+        }
     }
 
     // Create instruction data


### PR DESCRIPTION
- Introduced new pool structures for Futarchy, Humidifi, PancakeSwap, and Byreal in `pools.rs`, enhancing the pool management capabilities.
- Updated `MintPoolData` to include vectors for the new pool types and added methods to facilitate their addition.
- Modified `refresh.rs` to detect and initialize the new pool types, ensuring proper handling of their specific data structures.
- Enhanced `create_swap_instruction` in `transaction.rs` to include accounts for the new pool types, improving transaction capabilities.
- Updated module imports in `mod.rs` to include the new pool modules, ensuring proper organization and access to the new functionalities.